### PR TITLE
Increased cutoff angle when visibility test is disabled

### DIFF
--- a/libs/tex/calculate_data_costs.cpp
+++ b/libs/tex/calculate_data_costs.cpp
@@ -184,7 +184,8 @@ calculate_face_projection_infos(mve::TriangleMesh::ConstPtr mesh,
                 if (viewing_angle < 0.0f || viewing_direction.dot(view_to_face_vec) < 0.0f)
                     continue;
 
-                if (std::acos(viewing_angle) > MATH_DEG2RAD(75.0f))
+                float cutoffAngle = settings.geometric_visibility_test ? 75.0f : 90.0f;
+                if (std::acos(viewing_angle) > MATH_DEG2RAD(cutoffAngle))
                     continue;
 
                 /* Projects into the valid part of the TextureView? */


### PR DESCRIPTION
I'm proposing the addition of a larger cutoff angle for view selection, when geometric visibility is disabled, which is specific to OpenDroneMap. Often times datasets contain nadir shots. Meshes that have faces that are almost perpendicular (which is often in the case of 2.5D meshing) get discarded.

This does not affect normal usage, unless the "--skip-geometric-visibility-test" flag is passed.

See an example:

With 75 degrees cutoff:

![image](https://user-images.githubusercontent.com/1951843/34523480-ad758680-f065-11e7-871c-dcaa240533da.png)


With 90 degrees cutoff:

![image](https://user-images.githubusercontent.com/1951843/34523485-ba59b3a8-f065-11e7-8e2f-a87ff3dc30f5.png)


  