### PR TITLE
Regularization

### DIFF
--- a/libs/tex/generate_texture_patches.cpp
+++ b/libs/tex/generate_texture_patches.cpp
@@ -381,13 +381,9 @@ bool fill_hole(std::vector<std::size_t> const & hole, UniGraph const & graph,
             }
         }
 
-        for (std::size_t j = 0; j < matrix_size; ++j) {
-            coeff.push_back(Triplet(j, j, 1.0f));
-        }
-
         typedef Eigen::SparseMatrix<float> SpMat;
         SpMat A(matrix_size, matrix_size);
-        A.setFromTriplets(coeff.begin(), coeff.end());
+        A.setIdentity();
 
         Eigen::SparseLU<SpMat> solver;
         solver.analyzePattern(A);

--- a/libs/tex/global_seam_leveling.cpp
+++ b/libs/tex/global_seam_leveling.cpp
@@ -240,8 +240,13 @@ global_seam_leveling(UniGraph const & graph, mve::TriangleMesh::ConstPtr mesh,
     SpMat A(A_rows, x_rows);
     A.setFromTriplets(coefficients_A.begin(), coefficients_A.end());
 
-    SpMat Lhs = A.transpose() * A + Gamma.transpose() * Gamma;
-    /* Only keep lower triangle (CG only uses the lower), prune the rest and compress matrix. */
+    SpMat I(x_rows, x_rows);
+    I.setIdentity();
+
+    SpMat Lhs = A.transpose() * A + Gamma.transpose() * Gamma + I * 0.0001f;
+
+    /* Only keep lower triangle (CG only uses the lower),
+     * prune the rest and compress matrix. */
     Lhs.prune([](const int& row, const int& col, const float& value) -> bool {
             return col <= row && value != 0.0f;
         }); // value != 0.0f is only to suppress a compiler warning


### PR DESCRIPTION
Merging these changes drastically improves global seam leveling for many datasets, as reported in https://github.com/OpenDroneMap/OpenDroneMap/issues/801 and http://community.opendronemap.org/t/map-color-problem/350/6.

Without regularization:

![image](https://user-images.githubusercontent.com/1951843/38999987-f4c761f8-43c0-11e8-9c62-f11ba8d413b1.png)


With regularization: 

![image](https://user-images.githubusercontent.com/1951843/38999962-eaeb1f12-43c0-11e8-8c50-af157892d94b.png)
