### PR TITLE
Added --nadir option

### DIFF
--- a/apps/texrecon/arguments.cpp
+++ b/apps/texrecon/arguments.cpp
@@ -17,6 +17,7 @@
 #define WRITE_TIMINGS "write_timings"
 #define SKIP_HOLE_FILLING "skip_hole_filling"
 #define KEEP_UNSEEN_FACES "keep_unseen_faces"
+#define NADIR_MODE    "nadir_mode"
 
 Arguments parse_args(int argc, char **argv) {
     util::Arguments args;
@@ -82,6 +83,8 @@ Arguments parse_args(int argc, char **argv) {
         "Skip hole filling [false]");
     args.add_option('\0', KEEP_UNSEEN_FACES, false,
         "Keep unseen faces [false]");
+    args.add_option('\0', NADIR_MODE, false,
+        "Turn on nadir mode [false]");
     args.add_option('\0', WRITE_TIMINGS, false,
         "Write out timings for each algorithm step (OUT_PREFIX + _timings.csv)");
     args.add_option('\0', NO_INTERMEDIATE_RESULTS, false,
@@ -137,6 +140,8 @@ Arguments parse_args(int argc, char **argv) {
                 conf.settings.hole_filling = false;
             } else if (i->opt->lopt == KEEP_UNSEEN_FACES) {
                 conf.settings.keep_unseen_faces = true;
+            } else if (i->opt->lopt == NADIR_MODE) {
+                conf.settings.nadir_mode = true;
             } else if (i->opt->lopt == WRITE_TIMINGS) {
                 conf.write_timings = true;
             } else if (i->opt->lopt == NO_INTERMEDIATE_RESULTS) {

--- a/libs/tex/settings.h
+++ b/libs/tex/settings.h
@@ -92,6 +92,7 @@ struct Settings {
     bool local_seam_leveling = true;
     bool hole_filling = true;
     bool keep_unseen_faces = false;
+    bool nadir_mode = false;
 };
 
 TEX_NAMESPACE_END


### PR DESCRIPTION
This PR adds support for a new option, --nadir, which changes the behavior of the view selection algorithm to favor cameras closest to a triangle instead of the "optimal" camera to create better top-down ortho models.