### PR TITLE
Include headers for mapmap update

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -43,6 +43,7 @@ include_directories(SYSTEM
     ${CMAKE_SOURCE_DIR}/elibs/eigen
     ${CMAKE_SOURCE_DIR}/elibs/mapmap/
     ${CMAKE_SOURCE_DIR}/elibs/mapmap/mapmap
+    ${CMAKE_SOURCE_DIR}/elibs/mapmap/ext/dset
 )
 
 include_directories(


### PR DESCRIPTION
The recent [merge](https://github.com/dthuerck/mapmap_cpu/commit/bc6c333b61d4edc570b2c5ba5dec40e60a773677) added a reference to an external header file. 

This PR adds a reference to the new subdirectory in the include_directories command.

Pending approval from @pierotofy 