### PR TITLE
Fetch eigen from GitLab

### DIFF
--- a/elibs/CMakeLists.txt
+++ b/elibs/CMakeLists.txt
@@ -22,8 +22,8 @@ externalproject_add(ext_rayint
 
 externalproject_add(ext_eigen
     PREFIX          ext_eigen
-    URL             https://bitbucket.org/eigen/eigen/get/3.3.2.tar.gz
-    URL_MD5         36b5731ab7d7e0c10843ac93bd9fd270
+    URL             https://gitlab.com/libeigen/eigen/-/archive/3.3.2/eigen-3.3.2.tar.gz
+    URL_MD5         02edfeec591ae09848223d622700a10b
     SOURCE_DIR      ${CMAKE_SOURCE_DIR}/elibs/eigen
     CONFIGURE_COMMAND ""
     BUILD_COMMAND   ""


### PR DESCRIPTION
https://bitbucket.org/eigen/eigen had been migrated to  https://gitlab.com/libeigen/eigen

More Details: http://eigen.tuxfamily.org/index.php?title=News:Migration_to_GitLab.com_scheduled_on_the_December_4th

Related issue: https://github.com/OpenDroneMap/ODM/issues/1147