### PR TITLE
Removed -march=native flag

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -28,8 +28,7 @@ if(OPENMP_FOUND)
 endif()
 
 if(CMAKE_COMPILER_IS_GNUCXX)
-    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -march=native -Wall -Wextra -Wundef -pedantic")
-    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -mfpmath=sse -funroll-loops")
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -Wextra -Wundef -pedantic -funroll-loops")
 endif()
 
 find_package(PNG REQUIRED)

--- a/apps/texrecon/CMakeLists.txt
+++ b/apps/texrecon/CMakeLists.txt
@@ -4,6 +4,7 @@ file (GLOB SOURCES "[^_]*.cpp")
 set(BIN texrecon)
 
 add_executable(${BIN} ${SOURCES})
+target_compile_options(${BIN} PRIVATE -march=native)
 set_property(TARGET ${BIN} PROPERTY INTERPROCEDURAL_OPTIMIZATION True)
 add_dependencies(${BIN} ext_mve)
 target_link_libraries(${BIN} tex ${TBB_LIBRARIES} -lmve -lmve_util)


### PR DESCRIPTION
This flag propogates to all users of the library which makes them non-portable. Users of the library can still enable this flag if they wish. The binary sets the flag privately.

The `mfpmath=sse` is also non-portable although less extremely. It is the default on x64 architectures. 

We could make these variables completely private to the library following modern cmake best practices but that would be a larger change.